### PR TITLE
Vorschlag für ein anderes Modifier-Konzept

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,12 +94,13 @@ Varianten und Status einer Komponente werden mit Modifier abgebildet. Sie treten
 
 #### Beispiele
 
-`.button.primary`, `.text-link.unobtrusive`, `.product-list--entry.sold-out`, `.button.primary.disabled`
+`.button.is-primary`, `.text-link.is-unobtrusive`, `.product-list--entry.is-sold-out`, `.button.primary.is-disabled`
 
 #### Eigenschaften des Namens
 
 * beschreibt einen Zustand oder besonderes Verhalten einer Komponenteninstanz, wodurch eine Variante entsteht
-* ist idealerweise ein einfaches Adjektiv
+* ist idealerweise ein einfaches Adjektiv mit dem Prefix `is-` oder `has-`
+* die Prefixe werden benötigt, damit ein Modifier einfach identifiziert werden kann und auch Zustände ohne einfaches Adjektiv abgebildet werden können
 * steht nie alleine, sondern ist nur in Verbindung mit der Komponente eindeutig ([Warum?](https://github.com/zweitag/html-css-guidelines/pull/2#discussion_r123475470))
 
 ### Block, Element, Modifier (BEM)
@@ -130,7 +131,7 @@ Die Syntax von BEM finden wir jedoch etwas sperrig und haben uns für ein andere
       <pre lang="haml">
       %ul.fact-list
         %li.fact-list--entry
-        %li.fact-list--entry.highlighted
+        %li.fact-list--entry.is-highlighted
       </pre>
     </td>
   </tr>
@@ -151,7 +152,7 @@ Die Syntax von BEM finden wir jedoch etwas sperrig und haben uns für ein andere
         list-style-type: disc
       .fact-list--entry
         line-height: 1.2
-        &.highlighted
+        &.is-highlighted
           font-weight: 700
       </pre>
     </td>

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Varianten und Status einer Komponente werden mit Modifier abgebildet. Sie treten
 
 * beschreibt einen Zustand oder besonderes Verhalten einer Komponenteninstanz, wodurch eine Variante entsteht
 * ist idealerweise ein einfaches Adjektiv mit dem Prefix `is-` oder `has-`
-* die Prefixe werden benötigt, damit ein Modifier einfach identifiziert werden kann und auch Zustände ohne einfaches Adjektiv abgebildet werden können
+* die Prefixe werden benötigt, damit ein Modifier einfach identifiziert werden kann und Zustände abgebildet werden können, für die Adjektive nicht ausreichend sind
 * steht nie alleine, sondern ist nur in Verbindung mit der Komponente eindeutig ([Warum?](https://github.com/zweitag/html-css-guidelines/pull/2#discussion_r123475470))
 
 ### Block, Element, Modifier (BEM)

--- a/README.md
+++ b/README.md
@@ -94,12 +94,14 @@ Varianten und Status einer Komponente werden mit Modifier abgebildet. Sie treten
 
 #### Beispiele
 
-`.button.is-primary`, `.text-link.is-unobtrusive`, `.product-list--entry.is-sold-out`, `.button.primary.is-disabled`
+* `.button.is-primary`, `.text-link.is-unobtrusive`, `.product-list--entry.is-sold-out`, `.button.primary.is-disabled`,
+* `.navigation.has-submenu`, `.button.has-addon`
 
 #### Eigenschaften des Namens
 
 * beschreibt einen Zustand oder besonderes Verhalten einer Komponenteninstanz, wodurch eine Variante entsteht
-* ist idealerweise ein einfaches Adjektiv mit dem Prefix `is-` oder `has-`
+* wenn sich der Modifier auf den Zustand oder das Verhalten einer Komponenteninstanz bezieht, benutzt man das `is`-Prefix und ein einfaches Adjektiv
+* falls eine Komponenteninstanz sich auf einen Bestandteil der Komponenteninstanz bezieht, benutzt man das `has`-Prefix und ein einfaches Nomen
 * die Prefixe werden benötigt, damit ein Modifier einfach identifiziert werden kann und Zustände abgebildet werden können, für die Adjektive nicht ausreichend sind
 * steht nie alleine, sondern ist nur in Verbindung mit der Komponente eindeutig ([Warum?](https://github.com/zweitag/html-css-guidelines/pull/2#discussion_r123475470))
 

--- a/sass-style-guide.md
+++ b/sass-style-guide.md
@@ -78,13 +78,13 @@ Verschachtelungen innerhalb eines Elements beginnen mit Pseudoklassen, gefolgt v
     border-color: $color-border-loud
   &::before
     content: '*'
-  &.highlighted
+  &.is-highlighted
     background-color: $color-background-loud
 
 .main-navigation--link
   display: block
   padding: 5px 0
-  .main-navigation--item.highlighted &
+  .main-navigation--item.is-highlighted &
     color: $color-text-inverted
 ```
 


### PR DESCRIPTION
Wir haben uns gestern im HTML/CSS-Austausch über die leicht unterschiedlichen Modifier Konzepte in ZASAF und den Whitelabel Components unterhalten.

In diesem Fall haben wir uns darauf geeinigt, dass wir das Konzept mit den Prefixen `is` oder `has` sinnvoller finden. 
Folgende Gründe sprechen für die Umbenennung: 
- Identifizierung von Modifiern wird einfacher (z.B. auch die Suche nach `has-` oder `is-` innerhalb von Dateien)
- der aktuell gelebte Standard in Zweitag Projekten ist das Konzept mit `is-` bzw. `has-`
- nicht alles ist per einfachem Adjektiv möglich: gerade bei solchen Neologismen wie `submenued` kann es zu Unklarheiten führen, wenn man zusätzlich noch eine `submenu` Komponente besitzt.

Gegen die Umbenennung spricht, dass `is-` und `has-` keinen Vorteil für die individuelle Semantik eines Modifier enthalten. 

Ein Alternativvorschlag wäre, die Modifier per Zeichen zu trennen, z.B. `button | primary` o. `button [ primary disabled ]`. Damit würde man, neben der Nutzung einiger oben genannter Vorteile, auch dem Nachteil der Umbennenung entgegenwirken. 